### PR TITLE
Add time distribution to numpy file

### DIFF
--- a/module_0/make_numpy.py
+++ b/module_0/make_numpy.py
@@ -1,6 +1,9 @@
 from lutSim import *
 
-def MakeNumpyArray(t_lut, lut_geometry):
+def array_dtype(nbins_time):
+    return np.dtype([('vis','f4'), ('t0','f4'),('time_dist','f4',(int(nbins_time),))])
+
+def MakeNumpyArray(t_lut, lut_geometry, nbins_time):
     (lut_min, lut_max, lut_ndiv) = lut_geometry
     print(lut_min)
     print(lut_max)
@@ -11,7 +14,8 @@ def MakeNumpyArray(t_lut, lut_geometry):
     outputLUTarr = np.zeros((int(lut_ndiv[2]),
                              int(lut_ndiv[1]),
                              int(lut_ndiv[0]),
-                             n_op_channel, 2))
+                             n_op_channel),
+                             dtype=array_dtype(nbins_time))
 
     for i in range(int(lut_ndiv[0])):
         for j in range(int(lut_ndiv[1])):
@@ -36,15 +40,60 @@ def MakeNumpyArray(t_lut, lut_geometry):
 
     return outputLUTarr
 
+def GetVoxelInds(voxel, lut_geometry):
+    (lut_min,lut_max,lut_ndiv) = lut_geometry
+    voxel_xyz = (
+        voxel % int(lut_ndiv[0]),
+        (voxel//int(lut_ndiv[0])) % int(lut_ndiv[1]),
+        (voxel//(int(lut_ndiv[0])*int(lut_ndiv[1]))) % int(lut_ndiv[2])
+        )
+
+    return voxel_xyz
+
+def MakeNumpyArrayFast(t_lut, lut_geometry, nbins_time):
+    (lut_min, lut_max, lut_ndiv) = lut_geometry
+    print(lut_min)
+    print(lut_max)
+    print(lut_ndiv)
+
+    # output array has shape (nVoxX, nVoxY, nVoxZ, nOpChan, 2)
+    # last dimension is 0 = visibility, 1 = t0
+    outputLUTarr = np.zeros((int(lut_ndiv[2]),
+                             int(lut_ndiv[1]),
+                             int(lut_ndiv[0]),
+                             n_op_channel),
+                             dtype=array_dtype(nbins_time))
+
+    n = t_lut.GetEntries()
+    print(f'Voxels in tree: {n}')
+    for entry in range(n):
+        t_lut.GetEntry(entry)
+        i,j,k = GetVoxelInds(t_lut.Voxel, lut_geometry)
+        if entry < 10 or (n > 10 and entry > n - 10):
+            print(entry, (i,j,k), ':', t_lut.Voxel, t_lut.OpChannel, '|', t_lut.Visibility, t_lut.T1)
+        elif entry == 10:
+            print('...')
+
+        opChan = t_lut.OpChannel
+        outputLUTarr[k, j, i, opChan]['vis'] = t_lut.Visibility
+        outputLUTarr[k, j, i, opChan]['t0'] = t_lut.T1
+        outputLUTarr[k, j, i, opChan]['time_dist'] = np.frombuffer(t_lut.Time.fArray, dtype='f4', count=nbins_time+2)[1:-1] # skip under- and over-flow bins
+
+    return outputLUTarr
+
 def main():
     
     # link PhotonLibraryData
     t_lut = LoadLUT(args.lut)
 
+    # lookup number of time bins
+    t_lut.GetEntry(0)
+    nbins_time = int(t_lut.Time.GetNbinsX())
+
     # access LUT geometry
     lut_geometry = GetLutGeometry(args.lut)
 
-    arr = MakeNumpyArray(t_lut, lut_geometry)
+    arr = MakeNumpyArrayFast(t_lut, lut_geometry, nbins_time)
 
     np.save(args.output, arr)
 


### PR DESCRIPTION
This adds the time distribution to the numpy file. There are a couple changes to help with this:
 - the datatype in the NumPy file is now a structured array to better separate the visibility/t0/time_dist
 - A modified version of MakeNumpyArray (MakeNumpyArrayFast) speeds up the generation of this file

So for larnd-sim, we'll need to update the function to use structured arrays. Is this ok? I could also do it in a backwards compatible way (instead of the structured array, extend the `(..., 2)` shape array to be `(..., 2 + nbins)`), but I'm not a fan of this since it could be confusing for someone later on looking at the file.

